### PR TITLE
Added loading state to the refresh button

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,13 +3,30 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 function fetchCatFact() {
+    toggleBtnIndicator('refresh-btn');
+
     fetch('https://catfact.ninja/fact')
         .then(response => response.json())
         .then(data => {
+            toggleBtnIndicator('refresh-btn');
             updateCatFact( data.fact );
         });
 }
 
 function updateCatFact( fact ) {
     document.getElementById('cat-fact-text').innerHTML = fact;
+}
+
+function toggleBtnIndicator( btn_class ) {
+    const btn = document.getElementsByClassName(btn_class)[0];
+
+    if(btn.getAttribute('disabled') != null) {
+        btn.disabled = false;
+        btn.querySelectorAll(`:scope ${'.indicator-label'}`)[0].classList.remove("d-none");
+        btn.querySelectorAll(`:scope ${'.indicator-progress'}`)[0].classList.add("d-none");
+    } else {
+        btn.disabled = true;
+        btn.querySelectorAll(`:scope ${'.indicator-label'}`)[0].classList.add("d-none");
+        btn.querySelectorAll(`:scope ${'.indicator-progress'}`)[0].classList.remove("d-none");
+    }
 }

--- a/index.html
+++ b/index.html
@@ -14,7 +14,16 @@
         <div class="row">
             <div class="col-md-12">
                 <div class="d-flex justify-content-between">
-                    <h1>Cat Facts</h1><button class="btn btn-primary btn-lg ms-auto" type="button" onclick="fetchCatFact()"><i class="fas fa-sync-alt"></i><span class="ms-1">Refresh</span></button>
+                    <h1>Cat Facts</h1>
+                    <button class="btn btn-primary btn-lg ms-auto refresh-btn" type="button" onclick="fetchCatFact()">
+                        <span class="indicator-label">
+                            <i class="fas fa-sync-alt"></i><span class="ms-1">Refresh</span>
+                        </span>
+                        <span class="indicator-progress d-none">
+                            <span class="spinner-grow spinner-grow-sm" role="status" aria-hidden="true"></span>
+                            Fetching...
+                        </span>
+                    </button>
                 </div>
                 <div class="card mt-3">
                     <div class="card-body">


### PR DESCRIPTION
Just a minor commit. Show loading state to the button and disable button during data fetching to avoid API requests spamming (might only applicable/noticeable on slow network).